### PR TITLE
hs: Add newline to student's file when reflecting

### DIFF
--- a/src/hs/driver
+++ b/src/hs/driver
@@ -190,7 +190,7 @@ def mkStudentReflectorFile(srcFile : FilePath, dstDir : FilePath,
 
             for l in src:
                 dst.write("    " + l)
-            dst.write("    |]\n\n")
+            dst.write("\n    |]\n\n")
             dst.write(textwrap.dedent("""\
                 runASTCheck :: ASTCheck -> Q [Dec]
                 runASTCheck check = studentAST >>= check >> pure []


### PR DESCRIPTION
IS does not end the sent file with a line terminator, so when a comment
is a last line of the student's solution, the closing |] gets commented.